### PR TITLE
Set full path for useRouter import

### DIFF
--- a/scripts/page.tmpl.tsx
+++ b/scripts/page.tmpl.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from '@redneckz/wildless-cms-uni-blocks';
+import { useRouter } from '@redneckz/wildless-cms-uni-blocks/lib/hooks/useRouter';
 import { computeAPIFallback } from '@redneckz/wildless-cms-uni-blocks/lib/components/ContentPage/computeAPIFallback';
 import { ContentPage } from '@redneckz/wildless-cms-uni-blocks/lib/components/ContentPage/ContentPage';
 import { normalizePage } from '@redneckz/wildless-cms-uni-blocks/lib/components/ContentPage/normalizePage';


### PR DESCRIPTION
Установил полный путь в импорта useRouter для корректной работы механизма подмены в `/utils/applyTmpl.js`

https://github.com/redneckz/wildless-cms-uni-blocks/issues/1562